### PR TITLE
Fix duplicate recipe names and Tagged Recipe calculations

### DIFF
--- a/src/hooks/MainContext/MainContext.tsx
+++ b/src/hooks/MainContext/MainContext.tsx
@@ -14,6 +14,7 @@ import {
   sortByText,
   sortByTextExcludingWord,
 } from "../../utils/helpers";
+import { getSelectedRecipeVariant } from "../../utils/recipeHelper";
 import { getRecipes, getStores, getTags, listDBs } from "../../utils/restDbSdk";
 
 type MainContextType = {
@@ -229,6 +230,16 @@ export const MainContextProvider = (props: Props) => {
             ),
           } as CraftableProduct)
       )
+      .map((prod) => {
+        for (let i = 0; i < prod.RecipeVariants.length; ++i) {
+          const variant = prod.RecipeVariants[i];
+          if (prod.RecipeVariants.findIndex((v, j) => v.Variant.Key == variant.Variant.Key && i != j) >= 0) {
+            variant.Variant.Key += "" + i;
+          }
+        }
+        
+        return prod;
+      })
       .sort(
         (a, b) =>
           a.Name?.toLowerCase()?.localeCompare(b.Name?.toLowerCase() ?? "") ?? 0

--- a/src/pages/PriceCalculator/CalculatePriceView/IngredientsCalc.tsx
+++ b/src/pages/PriceCalculator/CalculatePriceView/IngredientsCalc.tsx
@@ -70,13 +70,11 @@ export default () => {
                 ]}
                 onChange={(selected: string | number) =>
                   update.craftAmmount(
-                    priceCalcStore.focusedNode()?.productName ?? "",
+                    priceCalcStore.storeKey(),
                     Number(selected)
                   )
                 }
-                selected={get.craftAmmount(
-                  priceCalcStore.focusedNode()?.productName
-                )}
+                selected={get.craftAmmount(priceCalcStore.storeKey())}
               />
             </LabeledField>
             <LabeledField vertical text="Upgrade module in use:">
@@ -87,11 +85,11 @@ export default () => {
                 }))}
                 onChange={(selected: string | number) =>
                   update.craftModule(
-                    priceCalcStore.focusedNode()?.productName ?? "",
+                    priceCalcStore.storeKey(),
                     Number(selected)
                   )
                 }
-                selected={get.craftModule(priceCalcStore.focusedNode()?.productName)}
+                selected={get.craftModule(priceCalcStore.storeKey())}
               />
             </LabeledField>
             <LabeledField vertical text="Lavish Talent:">
@@ -99,11 +97,11 @@ export default () => {
                 label="Enabled"
                 onChange={(isChecked: boolean) =>
                   update.craftLavish(
-                    priceCalcStore.focusedNode()?.productName ?? "",
+                    priceCalcStore.storeKey(),
                     isChecked,
                   )
                 }
-                checked={get.craftLavish(priceCalcStore.focusedNode()?.productName)}
+                checked={get.craftLavish(priceCalcStore.storeKey())}
               />
             </LabeledField>
             {(priceCalcStore.recipe()?.SkillNeeds.length ?? 0 > 0) &&

--- a/src/pages/PriceCalculator/CalculatePriceView/IngredientsCalc.tsx
+++ b/src/pages/PriceCalculator/CalculatePriceView/IngredientsCalc.tsx
@@ -70,11 +70,11 @@ export default () => {
                 ]}
                 onChange={(selected: string | number) =>
                   update.craftAmmount(
-                    priceCalcStore.storeKey(),
+                    priceCalcStore.variantId(),
                     Number(selected)
                   )
                 }
-                selected={get.craftAmmount(priceCalcStore.storeKey())}
+                selected={get.craftAmmount(priceCalcStore.variantId())}
               />
             </LabeledField>
             <LabeledField vertical text="Upgrade module in use:">
@@ -85,11 +85,11 @@ export default () => {
                 }))}
                 onChange={(selected: string | number) =>
                   update.craftModule(
-                    priceCalcStore.storeKey(),
+                    priceCalcStore.variantId(),
                     Number(selected)
                   )
                 }
-                selected={get.craftModule(priceCalcStore.storeKey())}
+                selected={get.craftModule(priceCalcStore.variantId())}
               />
             </LabeledField>
             <LabeledField vertical text="Lavish Talent:">
@@ -97,11 +97,11 @@ export default () => {
                 label="Enabled"
                 onChange={(isChecked: boolean) =>
                   update.craftLavish(
-                    priceCalcStore.storeKey(),
+                    priceCalcStore.variantId(),
                     isChecked,
                   )
                 }
-                checked={get.craftLavish(priceCalcStore.storeKey())}
+                checked={get.craftLavish(priceCalcStore.variantId())}
               />
             </LabeledField>
             {(priceCalcStore.recipe()?.SkillNeeds.length ?? 0 > 0) &&

--- a/src/pages/PriceCalculator/CalculatePriceView/ProductsCalc.tsx
+++ b/src/pages/PriceCalculator/CalculatePriceView/ProductsCalc.tsx
@@ -42,7 +42,7 @@ export default () => {
             <RadioToggle
               options={recipeMargins}
               onChange={(selected: string | number) =>
-                update.recipeMargin(priceCalcStore.storeKey(), Number(selected))
+                update.recipeMargin(priceCalcStore.variantId(), Number(selected))
               }
               selected={priceCalcStore.recipeMargin()}
             />
@@ -77,7 +77,7 @@ export default () => {
                         value={product.costPercentage}
                         onChange={(newValue) =>
                           update.costPercentage(
-                            priceCalcStore.storeKey(),
+                            priceCalcStore.variantId(),
                             fixPercentages(
                               priceCalcStore.costPercentages(),
                               product.Name,

--- a/src/pages/PriceCalculator/CalculatePriceView/ProductsCalc.tsx
+++ b/src/pages/PriceCalculator/CalculatePriceView/ProductsCalc.tsx
@@ -42,10 +42,7 @@ export default () => {
             <RadioToggle
               options={recipeMargins}
               onChange={(selected: string | number) =>
-                update.recipeMargin(
-                  priceCalcStore.selectedVariant()?.Recipe.Key ?? "",
-                  Number(selected)
-                )
+                update.recipeMargin(priceCalcStore.storeKey(), Number(selected))
               }
               selected={priceCalcStore.recipeMargin()}
             />
@@ -80,7 +77,7 @@ export default () => {
                         value={product.costPercentage}
                         onChange={(newValue) =>
                           update.costPercentage(
-                            priceCalcStore.selectedVariant()?.Variant.Key ?? "",
+                            priceCalcStore.storeKey(),
                             fixPercentages(
                               priceCalcStore.costPercentages(),
                               product.Name,

--- a/src/pages/PriceCalculator/context/createPriceCalcStore.ts
+++ b/src/pages/PriceCalculator/context/createPriceCalcStore.ts
@@ -48,6 +48,7 @@ export type PriceCalcStore = {
   selectedVariant: Accessor<RecipeVariant | undefined>;
   recipe: Accessor<Recipe | undefined>;
   recipeSkill: Accessor<string>;
+  storeKey: Accessor<string>;
   recipeIngredients: Accessor<
     (RecipeIngredient & {
       calcQuantity: number;
@@ -147,8 +148,10 @@ export default (): PriceCalcStore => {
     )
   );
 
+  const storeKey = createMemo(() => selectedVariant()?.Variant.Key ?? "");
+
   const recipeMargin = createMemo(() =>
-    get.recipeMargin(selectedVariant()?.Recipe.Key)
+    get.recipeMargin(storeKey())
   );
 
   const costPercentages = createMemo(() => {
@@ -247,6 +250,7 @@ export default (): PriceCalcStore => {
     selectedVariant,
     recipe,
     recipeSkill,
+    storeKey,
     selectedProduct,
     selectedRecipes,
     costPercentages,

--- a/src/pages/PriceCalculator/context/createPriceCalcStore.ts
+++ b/src/pages/PriceCalculator/context/createPriceCalcStore.ts
@@ -128,19 +128,6 @@ export default (): PriceCalcStore => {
     recipe()?.SkillNeeds?.[0]?.Skill ?? ""
   );
 
-  const craftModule = createMemo(() =>
-    get.craftModule(focusedProd())
-  );
-  const craftAmmount = createMemo(() =>
-    get.craftAmmount(focusedProd())
-  );
-  const craftLavish = createMemo(() => 
-    get.craftLavish(focusedProd())
-  );
-  const craftLevel = createMemo(() => 
-    get.craftLevel(recipeSkill())
-  );
-
   const selectedVariant = createMemo(() =>
     getSelectedOrFirstRecipeVariant(
       focusedNode()?.recipeVariants ?? [],
@@ -149,6 +136,19 @@ export default (): PriceCalcStore => {
   );
 
   const storeKey = createMemo(() => selectedVariant()?.Variant.Key ?? "");
+
+  const craftModule = createMemo(() =>
+    get.craftModule(storeKey())
+  );
+  const craftAmmount = createMemo(() =>
+    get.craftAmmount(storeKey())
+  );
+  const craftLavish = createMemo(() => 
+    get.craftLavish(storeKey())
+  );
+  const craftLevel = createMemo(() => 
+    get.craftLevel(recipeSkill())
+  );
 
   const recipeMargin = createMemo(() =>
     get.recipeMargin(storeKey())

--- a/src/pages/PriceCalculator/context/createPriceCalcStore.ts
+++ b/src/pages/PriceCalculator/context/createPriceCalcStore.ts
@@ -48,7 +48,7 @@ export type PriceCalcStore = {
   selectedVariant: Accessor<RecipeVariant | undefined>;
   recipe: Accessor<Recipe | undefined>;
   recipeSkill: Accessor<string>;
-  storeKey: Accessor<string>;
+  variantId: Accessor<string>;
   recipeIngredients: Accessor<
     (RecipeIngredient & {
       calcQuantity: number;
@@ -135,23 +135,23 @@ export default (): PriceCalcStore => {
     )
   );
 
-  const storeKey = createMemo(() => selectedVariant()?.Variant.Key ?? "");
+  const variantId = createMemo(() => selectedVariant()?.Variant.Key ?? "");
 
   const craftModule = createMemo(() =>
-    get.craftModule(storeKey())
+    get.craftModule(variantId())
   );
   const craftAmmount = createMemo(() =>
-    get.craftAmmount(storeKey())
+    get.craftAmmount(variantId())
   );
   const craftLavish = createMemo(() => 
-    get.craftLavish(storeKey())
+    get.craftLavish(variantId())
   );
   const craftLevel = createMemo(() => 
     get.craftLevel(recipeSkill())
   );
 
   const recipeMargin = createMemo(() =>
-    get.recipeMargin(storeKey())
+    get.recipeMargin(variantId())
   );
 
   const costPercentages = createMemo(() => {
@@ -250,7 +250,7 @@ export default (): PriceCalcStore => {
     selectedVariant,
     recipe,
     recipeSkill,
-    storeKey,
+    variantId,
     selectedProduct,
     selectedRecipes,
     costPercentages,


### PR DESCRIPTION
Both duplicate recipe names and tagged recipes were fixed in these commits. Some mods produced recipes with duplicate names to vanilla ones which confused the dropdown for selecting recipes. When trying to calculate the price for tagged items (when navigating to it from the recipe tree or link from another recipe) the UI was out of sync with the calculations. The UI would update the module store with something like "Tag: HewnLog" and calculations were trying to use the key "Hewn Log".